### PR TITLE
Minor compile fixes on older perl

### DIFF
--- a/lib/File/Map.xs
+++ b/lib/File/Map.xs
@@ -80,7 +80,7 @@ struct mmap_info {
 
 #ifdef WIN32
 
-static void get_sys_error(char* buffer, size_t buffer_size) {
+static void get_sys_error(pTHX_ char* buffer, size_t buffer_size) {
 	DWORD last_error = GetLastError(); 
 
 	DWORD format_flags = FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS;
@@ -130,7 +130,7 @@ static const struct {
 
 #else
 
-static void get_sys_error(char* buffer, size_t buffer_size) {
+static void get_sys_error(pTHX_ char* buffer, size_t buffer_size) {
 #ifdef HAS_STRERROR_R
 #	if STRERROR_R_PROTO == REENTRANT_PROTO_B_IBW
 	const char* message = strerror_r(errno, buffer, buffer_size);
@@ -140,7 +140,6 @@ static void get_sys_error(char* buffer, size_t buffer_size) {
 	strerror_r(errno, buffer, buffer_size);
 #	endif
 #else
-	pTHX;
 	const char* message = strerror(errno);
 	strncpy(buffer, message, buffer_size - 1);
 	buffer[buffer_size - 1] = '\0';
@@ -170,7 +169,7 @@ static size_t page_size() {
 
 static void S_die_sys(pTHX_ const char* format) {
 	char buffer[128];
-	get_sys_error(buffer, sizeof buffer);
+	get_sys_error(aTHX_ buffer, sizeof buffer);
 	Perl_croak(aTHX_ format, buffer);
 }
 #define die_sys(format) S_die_sys(aTHX_ format)
@@ -190,7 +189,7 @@ static void real_croak_pv(pTHX_ const char* value) {
 static void croak_sys(pTHX_ const char* format) {
 	char buffer[128];
 	SV* tmp;
-	get_sys_error(buffer, sizeof buffer);
+	get_sys_error(aTHX_ buffer, sizeof buffer);
 	tmp = sv_2mortal(newSVpvf(format, buffer, NULL));
 	real_croak_sv(aTHX_ tmp);
 }


### PR DESCRIPTION
I was unable to build File::Map on perl 5.8.7 thread-multi (don't ask, long story) but it failed because my_perl was not defined. Adding a pTHX fixes that problem. Then I got a segv in the strerror call for a test in 20-errors.t. I think that's caused by a problem with the thread local buffers when strerror is remapped to strerror_r. It was then I realised that we should be in the strerror_r path anyhow and saw that the config.h include file uses HAS_STRERROR_R rather than HAVE_STRERROR_R. Making that change lets the module build with all tests passing.
