### PR TITLE
Fix test failures on hurd-i386.

### DIFF
--- a/lib/File/Map.xs
+++ b/lib/File/Map.xs
@@ -139,7 +139,7 @@ static size_t page_size() {
 }
 #endif
 
-#ifdef VMS
+#if defined(VMS) || defined(__GNU__)
 #define madvise(address, length, advice) 0
 #endif
 

--- a/t/20-threads.t
+++ b/t/20-threads.t
@@ -5,7 +5,7 @@ use warnings;
 use Config;
 BEGIN {
 	# Yes, this is really necessary
-	if ($Config{useithreads}) {
+	if ($Config{useithreads} && $^O ne 'gnu') {
 		require threads;
 		threads->import();
 		require Test::More;


### PR DESCRIPTION
The following changes were required to fix the test failures on the GNU/Hurd build systems for the libfile-map-perl Debian package:
- Make madvise() no-op, not implemented on Hurd.
- Skip threads tests, thread implementation problematic.
