### PR TITLE
Fix unresolved symbol "madvise" on QNX NTO

### DIFF
--- a/lib/File/Map.xs
+++ b/lib/File/Map.xs
@@ -34,6 +34,10 @@
 #	include <unistd.h>
 #endif /* WIN32 */
 
+#ifdef __QNX__
+# define madvise posix_madvise
+#endif
+
 #ifndef MAP_ANONYMOUS
 #	define MAP_ANONYMOUS MAP_ANON
 #elif !defined MAP_ANON


### PR DESCRIPTION
NTO doesn't have madvise, but does have posix_madvise
in sys/mman.h

Have tested on QNX NTO 6.5.0 system

Sample CPAN Test report:
http://www.cpantesters.org/cpan/report/87cdc64e-1b7a-11ea-9066-e374b0ba08e8